### PR TITLE
change max token for workshop #3

### DIFF
--- a/03_Assigning_Roles_Role_Prompting.ipynb
+++ b/03_Assigning_Roles_Role_Prompting.ipynb
@@ -48,7 +48,7 @@
     "def get_completion(prompt, system_prompt=None):\n",
     "    inference_config = {\n",
     "        \"temperature\": 0.0,\n",
-    "        \"maxTokens\": 200\n",
+    "        \"maxTokens\": 500\n",
     "    }\n",
     "    converse_api_params = {\n",
     "        \"modelId\": modelId,\n",


### PR DESCRIPTION
*Issue #, if available:*
The response is trimmed because of the short max token length.
<img width="1593" alt="image" src="https://github.com/aws-samples/prompt-engineering-with-anthropic-claude-v-3/assets/1736420/2a2bfec1-10e9-460b-8f71-7a4a18959d5d">
*Description of changes:*
I changed the max token length from 200 to 500.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


