### PR TITLE
not referencing question variable

### DIFF
--- a/10_4_3_Reading_Charts_Graphs_Powerpoints.ipynb
+++ b/10_4_3_Reading_Charts_Graphs_Powerpoints.ipynb
@@ -145,7 +145,7 @@
     "        {\n",
     "            \"role\": 'user',\n",
     "            \"content\": [\n",
-    "                {\"text\": f\"{question}\"},\n",
+    "                {\"text\": \"{question}\"},\n",
     "                {\"image\": {\n",
     "                    \"format\": 'png',\n",
     "                    \"source\": {\"bytes\": image_file }\n",

--- a/10_4_3_Reading_Charts_Graphs_Powerpoints.ipynb
+++ b/10_4_3_Reading_Charts_Graphs_Powerpoints.ipynb
@@ -145,7 +145,7 @@
     "        {\n",
     "            \"role\": 'user',\n",
     "            \"content\": [\n",
-    "                {\"text\": \"What's in this image? Answer in a single sentence.\"},\n",
+    "                {\"text\": f\"{question}\"},\n",
     "                {\"image\": {\n",
     "                    \"format\": 'png',\n",
     "                    \"source\": {\"bytes\": image_file }\n",

--- a/10_4_3_Reading_Charts_Graphs_Powerpoints.ipynb
+++ b/10_4_3_Reading_Charts_Graphs_Powerpoints.ipynb
@@ -145,7 +145,7 @@
     "        {\n",
     "            \"role\": 'user',\n",
     "            \"content\": [\n",
-    "                {\"text\": \"{question}\"},\n",
+    "                {\"text\": question},\n",
     "                {\"image\": {\n",
     "                    \"format\": 'png',\n",
     "                    \"source\": {\"bytes\": image_file }\n",


### PR DESCRIPTION
*Issue #, if available:*
Recently attended an AWS workshop and use this series of notebooks at material. Issue is regarding to a code error in notebook 10_4_3.
`question` variable was not referenced. Thus, when looping through the `questions` list, it outputted the same answer as the question was a static string.

*Description of changes:*
Switch out the static string to referencing the `question` variable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
