### PR TITLE
Fix typo in 09_Complex_Prompts_from_Scratch.ipynb

### DIFF
--- a/09_Complex_Prompts_from_Scratch.ipynb
+++ b/09_Complex_Prompts_from_Scratch.ipynb
@@ -456,7 +456,7 @@
     "\n",
     "We suggest you read through the variable content (in this case, `{QUESTION}` and `{TAX_CODE}`) to understand what content Claude is expected to work with. Be sure to reference `{QUESTION}` and `{TAX_CODE}` directly in your prompt somewhere (using f-string syntax like in the other examples) so that the actual variable content can be substituted in.\n",
     "\n",
-    "Fill in the prompt element fields with content that match the description and the examples you've seen in the preceding examples of complex prompts. Once you have filled out all the prompt elements that you want to fill out, run the cell to see the concatenated prompt as well as Claude's response.\n",
+    "Fill in the prompt element fields with content that matches the description and the examples you've seen in the preceding examples of complex prompts. Once you have filled out all the prompt elements that you want to fill out, run the cell to see the concatenated prompt as well as Claude's response.\n",
     "\n",
     "Remember that prompt engineering is rarely purely formulaic, especially for large and complex prompts! It's important to develop test cases and **try a variety of prompts and prompt structures to see what works best for each situation**. Note that if you *do* change the ordering of the prompt elements, you should also remember to change the ordering of the concatenaton in the `COMBINE ELEMENTS` section."
    ]


### PR DESCRIPTION
This fixes a small singular/plural agreement typo in 09_Complex_Prompts_from_Scratch.ipynb:

"Fill in the prompt element fields with content that match..." ->
"Fill in the prompt element fields with content that matches..."
